### PR TITLE
[Quarkus Monolith] Expose order version

### DIFF
--- a/monolith-quarkus-synch/src/main/java/org/pwte/example/domain/Order.java
+++ b/monolith-quarkus-synch/src/main/java/org/pwte/example/domain/Order.java
@@ -50,7 +50,6 @@ public class Order implements Serializable {
 	@Version
 	protected long version;
 	  
-	@JsonbTransient
 	public long getVersion() {
 		return version;
 	}


### PR DESCRIPTION
Currently `/CustomerOrderServicesWeb/jaxrs/Customer/Orders` doesn't expose the order version. This means the only way to delete an order is to try incrementing the `If-Match` header until the right value is found.

This patch exposes the version, which makes it trivial to delete any order items.