### PR TITLE
[Quarkus Monolith] Make line items deletable

### DIFF
--- a/monolith-quarkus-synch/src/main/java/org/pwte/example/service/CustomerOrderServicesImpl.java
+++ b/monolith-quarkus-synch/src/main/java/org/pwte/example/service/CustomerOrderServicesImpl.java
@@ -180,6 +180,7 @@ public class CustomerOrderServicesImpl implements CustomerOrderServices {
 		customer.setOpenOrder(null);
 	}
 
+	@Transactional
 	public Order removeLineItem(int productId,long version) throws CustomerDoesNotExistException, OrderNotOpenException, ProductDoesNotExistException, NoLineItemsException, GeneralPersistenceException, OrderModifiedException {
 		Product product = em.find(Product.class,productId);
 		if(product == null) throw new ProductDoesNotExistException();


### PR DESCRIPTION
Currently line items aren't deletable, the backend throws an exception. This fixes it.