### PR TITLE
Add the missing @Inject annotation

### DIFF
--- a/service-catalog-quarkus-reactive/src/main/java/com/ibm/catalog/ProductResource.java
+++ b/service-catalog-quarkus-reactive/src/main/java/com/ibm/catalog/ProductResource.java
@@ -140,7 +140,8 @@ public class ProductResource {
                 })
                 .subscribeAsCompletionStage();            
     }
-    
+
+    @Inject
     @ConfigProperty(name = "kafka.bootstrap.servers")
     String kafkaBootstrapServer;
 


### PR DESCRIPTION
When using the `@ConfigProperty` annotation from Microprofile on a field, the field must be annotated with `@Inject`.